### PR TITLE
Clever Challenge - Paul-Andre Henegar

### DIFF
--- a/countFunctionCalls.go
+++ b/countFunctionCalls.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+)
+
+func beginsIdentifier(b byte) bool {
+	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') || b == '_'
+}
+
+func insideIdentifier(b byte) bool {
+	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') || ('0' <= b && b <= '9') || b == '_'
+}
+
+type tokenType int
+
+const (
+	endOfString tokenType = -1
+	identifier  tokenType = iota
+	somethingElse
+)
+
+// A "tokenizer" that removes characters to be ignored and splits its input
+// into things that look like identifiers and all other characters.
+//
+// It could be replaced by a more complete tokenizer. One that takes care of
+// comments and strings for example
+type tokenizer struct {
+	text        []byte
+	toBeIgnored []byte
+}
+
+func byteInSlice(b byte, slice []byte) bool {
+	for _, c := range slice {
+		if b == c {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *tokenizer) Next() (token tokenType, text []byte) {
+
+	for len(r.text) > 0 && byteInSlice(r.text[0], r.toBeIgnored) {
+		r.text = r.text[1:]
+	}
+
+	if len(r.text) == 0 {
+		return endOfString, nil
+	}
+
+	if beginsIdentifier(r.text[0]) {
+		var i = 1
+		for i < len(r.text) && insideIdentifier(r.text[i]) {
+			i++
+		}
+		var result = r.text[0:i]
+		r.text = r.text[i:]
+		return identifier, result
+	}
+
+	var result = r.text[:1]
+	r.text = r.text[1:]
+	return somethingElse, result
+
+}
+
+func countCFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
+
+	var keywords = map[string]bool{
+		"if":    true,
+		"for":   true,
+		"while": true,
+		"else":  true,
+	}
+
+	var whitespace = []byte{
+		' ',
+		'\t',
+		'\n',
+		'\r',
+		'\f',
+	}
+
+	var tokenizer = tokenizer{
+		buffer.Bytes(),
+		whitespace,
+	}
+
+	var tokens = [3]tokenType{somethingElse, somethingElse, somethingElse}
+	var strings = [3][]byte{{' '}, {' '}, {' '}}
+
+	for {
+		tok, s := tokenizer.Next()
+		if tok == endOfString {
+			return
+		}
+
+		tokens[0], tokens[1], tokens[2] = tokens[1], tokens[2], tok
+		strings[0], strings[1], strings[2] = strings[1], strings[2], s
+
+		if !(tokens[0] == identifier && !keywords[string(strings[0])]) &&
+			tokens[1] == identifier && !keywords[string(strings[1])] &&
+			tokens[2] == somethingElse && strings[2][0] == '(' {
+			(*counts)[string(strings[1])]++
+		}
+	}
+}
+
+func countPythonFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
+
+	// Since the open parenthesis for a function call must be on the same line as
+	// the name, I only ignore space and tabs.
+	var whitespace = []byte{
+		' ',
+		'\t',
+	}
+
+	var keywords = map[string]bool{
+		"if":    true,
+		"in":    true,
+		"or":    true,
+		"and":   true,
+		"for":   true,
+		"while": true,
+		"else":  true,
+		"elif":  true,
+		"def":   true,
+	}
+
+	var tokenizer = tokenizer{
+		buffer.Bytes(),
+		whitespace,
+	}
+
+	var tokens = [3]tokenType{somethingElse, somethingElse, somethingElse}
+	var strings = [3][]byte{{' '}, {' '}, {' '}}
+
+	for {
+		tok, s := tokenizer.Next()
+		if tok == endOfString {
+			return
+		}
+
+		tokens[0], tokens[1], tokens[2] = tokens[1], tokens[2], tok
+		strings[0], strings[1], strings[2] = strings[1], strings[2], s
+
+		if !(tokens[0] == identifier && string(strings[0]) == "def") &&
+			tokens[1] == identifier && !keywords[string(tokens[1])] &&
+			tokens[2] == somethingElse && strings[2][0] == '(' {
+			(*counts)[string(strings[1])]++
+		}
+	}
+}
+
+//Given a bytes.Buffer containing a code segment, its extension, and a map to
+//use for counting, counts the function calls
+func countFunctionCalls(buffer *bytes.Buffer, ext string, counts *map[string]int) {
+	switch ext {
+	case ".c", ".h":
+		countCFunctionCalls(buffer, counts)
+	case ".py":
+		countPythonFunctionCalls(buffer, counts)
+
+	default:
+
+	}
+}

--- a/countFunctionCalls.go
+++ b/countFunctionCalls.go
@@ -24,7 +24,7 @@ const (
 // into things that look like identifiers and all other characters.
 //
 // It could be replaced by a more complete tokenizer. One that takes care of
-// comments and strings for example
+// comments and strings for example.
 type tokenizer struct {
 	text        []byte
 	toBeIgnored []byte
@@ -39,6 +39,7 @@ func byteInSlice(b byte, slice []byte) bool {
 	return false
 }
 
+// Get next token and text slice that goes with it
 func (r *tokenizer) Next() (token tokenType, text []byte) {
 
 	for len(r.text) > 0 && byteInSlice(r.text[0], r.toBeIgnored) {
@@ -67,19 +68,19 @@ func (r *tokenizer) Next() (token tokenType, text []byte) {
 
 func countCFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
 
-	var keywords = map[string]bool{
-		"if":    true,
-		"for":   true,
-		"while": true,
-		"else":  true,
-	}
-
 	var whitespace = []byte{
 		' ',
 		'\t',
 		'\n',
 		'\r',
 		'\f',
+	}
+
+	var keywords = map[string]bool{
+		"if":    true,
+		"for":   true,
+		"while": true,
+		"else":  true,
 	}
 
 	var tokenizer = tokenizer{
@@ -110,7 +111,7 @@ func countCFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
 func countPythonFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
 
 	// Since the open parenthesis for a function call must be on the same line as
-	// the name, I only ignore space and tabs.
+	// the name, I only ignore spaces and tabs.
 	var whitespace = []byte{
 		' ',
 		'\t',

--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ func compute() *result {
 
 	// I use sets instead of lists for files that we've seen
 	var seenFiles = make(map[string]struct{})
-	var seenExtensions = make(map[string]struct{})
 
 	// When reading in a region, I will be reading it into these buffers
 	var currentRegionBefore, currentRegionAfter bytes.Buffer
@@ -79,7 +78,6 @@ func compute() *result {
 			if fileName == "/dev/null" {
 				fileType = "/dev/null"
 			}
-			seenExtensions[fileType] = struct{}{}
 			if line[0] == '-' {
 				currentExtensionBefore = fileType
 			} else {
@@ -159,10 +157,6 @@ func compute() *result {
 	// Turn set into list
 	for name, _ := range seenFiles {
 		r.files = append(r.files, name)
-	}
-
-	for name, _ := range seenExtensions {
-		r.fileExtensions = append(r.fileExtensions, name)
 	}
 
 	// Combine the two functionCalls maps into one

--- a/main.go
+++ b/main.go
@@ -29,168 +29,6 @@ func main() {
 	fmt.Println(compute())
 }
 
-func beginsIdentifier(b byte) bool {
-	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') || b == '_'
-}
-func insideIdentifier(b byte) bool {
-	return ('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') || ('0' <= b && b <= '9') || b == '_'
-}
-
-type tokenType int
-const (
-	endOfString tokenType = -1
-	identifier  tokenType = iota
-	somethingElse
-)
-
-// A "tokenizer" that removes characters to be ignored and splits its input
-// into things that look like identifiers and all other characters.
-//
-// It could be replaced by a more complete tokenizer. One that takes care of
-// comments and strings for example
-type tokenizer struct {
-	text        []byte
-	toBeIgnored []byte
-}
-
-func byteInSlice(b byte, slice []byte) bool {
-	for _, c := range slice {
-		if b == c {
-			return true
-		}
-	}
-	return false
-}
-
-
-func (r *tokenizer) Next() (token tokenType, text []byte) {
-
-	for len(r.text) > 0 && byteInSlice(r.text[0], r.toBeIgnored) {
-		r.text = r.text[1:]
-	}
-
-	if len(r.text) == 0 {
-		return endOfString, nil
-	}
-
-	if beginsIdentifier(r.text[0]) {
-		var i = 1
-		for i < len(r.text) && insideIdentifier(r.text[i]) {
-			i++
-		}
-		var result = r.text[0:i]
-		r.text = r.text[i:]
-		return identifier, result
-	}
-
-	var result = r.text[:1]
-	r.text = r.text[1:]
-	return somethingElse, result
-
-}
-
-func countCFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
-
-	var keywords = map[string]bool{
-		"if":    true,
-		"for":   true,
-		"while": true,
-		"else": true,
-	}
-
-	var whitespace = []byte{
-		' ',
-		'\t',
-		'\n',
-		'\r',
-		'\f',
-	}
-
-	var tokenizer = tokenizer{
-		buffer.Bytes(),
-		whitespace,
-	}
-
-	var tokens = [3]tokenType{somethingElse, somethingElse, somethingElse}
-	var strings = [3][]byte{{' '}, {' '}, {' '}}
-
-	for {
-		tok, s := tokenizer.Next()
-		if tok == endOfString {
-			return
-		}
-
-		tokens[0], tokens[1], tokens[2] = tokens[1], tokens[2], tok
-		strings[0], strings[1], strings[2] = strings[1], strings[2], s
-
-		if !(tokens[0] == identifier && !keywords[string(strings[0])]) &&
-			tokens[1] == identifier && !keywords[string(strings[1])] &&
-			tokens[2] == somethingElse && strings[2][0] == '(' {
-			(*counts)[string(strings[1])]++
-		}
-	}
-}
-
-func countPythonFunctionCalls(buffer *bytes.Buffer, counts *map[string]int) {
-
-	// Since the open parenthesis for a function call must be on the same line as
-	// the name, I only ignore space and tabs.
-	var whitespace = []byte{
-		' ',
-		'\t',
-	}
-
-	var keywords = map[string]bool{
-		"if":    true,
-		"in":    true,
-		"or":    true,
-		"and":    true,
-		"for":   true,
-		"while": true,
-		"else": true,
-		"elif": true,
-		"def": true,
-	}
-
-	var tokenizer = tokenizer{
-		buffer.Bytes(),
-		whitespace,
-	}
-
-	var tokens = [3]tokenType{somethingElse, somethingElse, somethingElse}
-	var strings = [3][]byte{{' '}, {' '}, {' '}}
-
-	for {
-		tok, s := tokenizer.Next()
-		if tok == endOfString {
-			return
-		}
-
-		tokens[0], tokens[1], tokens[2] = tokens[1], tokens[2], tok
-		strings[0], strings[1], strings[2] = strings[1], strings[2], s
-
-		if !(tokens[0] == identifier && string(strings[0]) == "def") &&
-		 tokens[1] == identifier && !keywords[string(tokens[1])] &&
-			tokens[2] == somethingElse && strings[2][0] == '(' {
-			(*counts)[string(strings[1])]++
-		}
-	}
-}
-
-//Given a bytes.Buffer containing a code segment, its extension, and a map to
-//use for counting, counts the function calls
-func countFunctionCalls(buffer *bytes.Buffer, ext string, counts *map[string]int) {
-	switch ext {
-	case ".c", ".h":
-		countCFunctionCalls(buffer, counts)
-	case ".py":
-		countPythonFunctionCalls(buffer, counts)
-
-	default:
-
-	}
-}
-
 //compute parses the git diffs in ./diffs and returns
 //a result struct that contains all the relevant informations
 //about these diffs
@@ -214,14 +52,14 @@ func compute() *result {
 	// Here I create a small state machine using state functions
 	type stateFn func(line string) stateFn
 	var processFileHeaderLine,
-	processRegionHeaderLine,
-	processCodeLine stateFn
+		processRegionHeaderLine,
+		processCodeLine stateFn
 
 	processFileHeaderLine = func(line string) stateFn {
 		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
 
 			var fileName = line[len("--- "):]
-			if (fileName != "/dev/null") {
+			if fileName != "/dev/null" {
 				fileName = fileName[len("a/"):]
 			}
 
@@ -234,7 +72,7 @@ func compute() *result {
 				fileType = filepath.Base(fileName)
 			}
 			seenExtensions[fileType] = struct{}{}
-			if (line[0] == '-') {
+			if line[0] == '-' {
 				currentExtensionBefore = fileType
 			} else {
 				currentExtensionAfter = fileType
@@ -292,8 +130,6 @@ func compute() *result {
 		}
 
 		scanner := bufio.NewScanner(diffFile)
-
-
 
 		var state = processFileHeaderLine
 		for scanner.Scan() {

--- a/result.go
+++ b/result.go
@@ -15,8 +15,9 @@ type result struct {
 	lineAdded int
 	//How many line were deleted totla
 	lineDeleted int
-	//How many times the function seen in the code are called.
-	functionCalls map[string]int
+	//How many times the functionj seen in the code are called before and after
+	functionCallsBefore map[string]int
+	functionCallsAfter  map[string]int
 }
 
 //String returns the value of results as a formated string
@@ -33,8 +34,13 @@ func (r *result) String() string {
 	r.appendIntValueToBuffer(r.lineAdded, "LA", &buffer)
 	r.appendIntValueToBuffer(r.lineDeleted, "LD", &buffer)
 
-	buffer.WriteString("Functions calls: \n")
-	for key, value := range r.functionCalls {
+	buffer.WriteString("Function calls before: \n")
+	for key, value := range r.functionCallsBefore {
+		r.appendIntValueToBuffer(value, key, &buffer)
+	}
+
+	buffer.WriteString("Function calls after: \n")
+	for key, value := range r.functionCallsAfter {
 		r.appendIntValueToBuffer(value, key, &buffer)
 	}
 

--- a/result.go
+++ b/result.go
@@ -26,12 +26,14 @@ type result struct {
 func (r *result) String() string {
 
 	var buffer bytes.Buffer
+	/*
 	buffer.WriteString("Files: \n")
 	for _, file := range r.files {
 		buffer.WriteString("	-")
 		buffer.WriteString(file)
 		buffer.WriteString("\n")
 	}
+	*/
 	buffer.WriteString("Extensions: \n")
 	for _, ext := range r.fileExtensions {
 		buffer.WriteString("	-")

--- a/result.go
+++ b/result.go
@@ -33,7 +33,7 @@ func (r *result) String() string {
 	}
 	buffer.WriteString("Extensions: \n")
 	for _, ext := range r.fileExtensions {
-		buffer.WriteString("	-")
+		buffer.WriteString("\t-")
 		buffer.WriteString(ext)
 		buffer.WriteString("\n")
 	}
@@ -43,6 +43,7 @@ func (r *result) String() string {
 
 	buffer.WriteString("Function calls (before, after): \n")
 	for key, value := range r.functionCalls {
+		buffer.WriteString("\t")
 		buffer.WriteString(key)
 		buffer.WriteString(" : ")
 		buffer.WriteString(strconv.Itoa(value.before))

--- a/result.go
+++ b/result.go
@@ -26,14 +26,12 @@ type result struct {
 func (r *result) String() string {
 
 	var buffer bytes.Buffer
-	/*
 	buffer.WriteString("Files: \n")
 	for _, file := range r.files {
 		buffer.WriteString("	-")
 		buffer.WriteString(file)
 		buffer.WriteString("\n")
 	}
-	*/
 	buffer.WriteString("Extensions: \n")
 	for _, ext := range r.fileExtensions {
 		buffer.WriteString("	-")
@@ -44,6 +42,7 @@ func (r *result) String() string {
 	r.appendIntValueToBuffer(r.lineAdded, "LA", &buffer)
 	r.appendIntValueToBuffer(r.lineDeleted, "LD", &buffer)
 
+
 	buffer.WriteString("Function calls before: \n")
 	for key, value := range r.functionCallsBefore {
 		r.appendIntValueToBuffer(value, key, &buffer)
@@ -53,6 +52,7 @@ func (r *result) String() string {
 	for key, value := range r.functionCallsAfter {
 		r.appendIntValueToBuffer(value, key, &buffer)
 	}
+
 
 	return buffer.String()
 }

--- a/result.go
+++ b/result.go
@@ -18,8 +18,7 @@ type result struct {
 	//How many line were deleted totla
 	lineDeleted int
 	//How many times the functionj seen in the code are called before and after
-	functionCallsBefore map[string]int
-	functionCallsAfter  map[string]int
+	functionCalls map[string]struct{ before, after int }
 }
 
 //String returns the value of results as a formated string
@@ -27,13 +26,11 @@ func (r *result) String() string {
 
 	var buffer bytes.Buffer
 	buffer.WriteString("Files: \n")
-	/*
 	for _, file := range r.files {
 		buffer.WriteString("	-")
 		buffer.WriteString(file)
 		buffer.WriteString("\n")
 	}
-	*/
 	buffer.WriteString("Extensions: \n")
 	for _, ext := range r.fileExtensions {
 		buffer.WriteString("	-")
@@ -44,17 +41,15 @@ func (r *result) String() string {
 	r.appendIntValueToBuffer(r.lineAdded, "LA", &buffer)
 	r.appendIntValueToBuffer(r.lineDeleted, "LD", &buffer)
 
-	/*
-	buffer.WriteString("Function calls before: \n")
-	for key, value := range r.functionCallsBefore {
-		r.appendIntValueToBuffer(value, key, &buffer)
+	buffer.WriteString("Function calls (before, after): \n")
+	for key, value := range r.functionCalls {
+		buffer.WriteString(key)
+		buffer.WriteString(" : ")
+		buffer.WriteString(strconv.Itoa(value.before))
+		buffer.WriteString(", ")
+		buffer.WriteString(strconv.Itoa(value.after))
+		buffer.WriteString("\n")
 	}
-
-	buffer.WriteString("Function calls after: \n")
-	for key, value := range r.functionCallsAfter {
-		r.appendIntValueToBuffer(value, key, &buffer)
-	}
-	*/
 
 	return buffer.String()
 }

--- a/result.go
+++ b/result.go
@@ -9,6 +9,8 @@ import (
 type result struct {
 	//The name of the files seen
 	files []string
+	//The name of the files seen
+	fileExtensions []string
 	//How many region we have (i.e. seperated by @@)
 	regions int
 	//How many line were added total
@@ -28,6 +30,12 @@ func (r *result) String() string {
 	for _, file := range r.files {
 		buffer.WriteString("	-")
 		buffer.WriteString(file)
+		buffer.WriteString("\n")
+	}
+	buffer.WriteString("Extensions: \n")
+	for _, ext := range r.fileExtensions {
+		buffer.WriteString("	-")
+		buffer.WriteString(ext)
 		buffer.WriteString("\n")
 	}
 	r.appendIntValueToBuffer(r.regions, "Regions", &buffer)

--- a/result.go
+++ b/result.go
@@ -10,8 +10,6 @@ type result struct {
 	//The name of the files seen
 	files []string
 	//The name of the files seen
-	fileExtensions []string
-	//How many region we have (i.e. seperated by @@)
 	regions int
 	//How many line were added total
 	lineAdded int
@@ -29,12 +27,6 @@ func (r *result) String() string {
 	for _, file := range r.files {
 		buffer.WriteString("	-")
 		buffer.WriteString(file)
-		buffer.WriteString("\n")
-	}
-	buffer.WriteString("Extensions: \n")
-	for _, ext := range r.fileExtensions {
-		buffer.WriteString("\t-")
-		buffer.WriteString(ext)
 		buffer.WriteString("\n")
 	}
 	r.appendIntValueToBuffer(r.regions, "Regions", &buffer)

--- a/result.go
+++ b/result.go
@@ -27,11 +27,13 @@ func (r *result) String() string {
 
 	var buffer bytes.Buffer
 	buffer.WriteString("Files: \n")
+	/*
 	for _, file := range r.files {
 		buffer.WriteString("	-")
 		buffer.WriteString(file)
 		buffer.WriteString("\n")
 	}
+	*/
 	buffer.WriteString("Extensions: \n")
 	for _, ext := range r.fileExtensions {
 		buffer.WriteString("	-")
@@ -42,7 +44,7 @@ func (r *result) String() string {
 	r.appendIntValueToBuffer(r.lineAdded, "LA", &buffer)
 	r.appendIntValueToBuffer(r.lineDeleted, "LD", &buffer)
 
-
+	/*
 	buffer.WriteString("Function calls before: \n")
 	for key, value := range r.functionCallsBefore {
 		r.appendIntValueToBuffer(value, key, &buffer)
@@ -52,7 +54,7 @@ func (r *result) String() string {
 	for key, value := range r.functionCallsAfter {
 		r.appendIntValueToBuffer(value, key, &buffer)
 	}
-
+	*/
 
 	return buffer.String()
 }


### PR DESCRIPTION
## Api change
I changed the result struct slightly. In the `functionCalls` member, I count the number of function calls before and after the diff separately, like `	functionCalls map[string]struct{ before, after int }`.

## Approach

My approach for the first 4 parts is relatively straightforward, with the only slightly interesting thing being that I used state functions (inspired by https://talks.golang.org/2011/lex.slide#1) and closures.

My approach for counting function calls was reading in the regions one at a time, tokenizing them and deciding if sequences of tokens are considered to be function calls. I read each region into two buffers, one for the before version, one for the after version, and counted function calls separately.

My "tokenizer" is really basic, and only distinguishes what looks like identifiers from whitespace and other characters. It does not treat comments or strings correctly, so my code would currently count a function call inside a comment. The tokenizer could be extended or replaced by an actual tokenizer without any problem. I tried using a regexp based tokenizer at first and it was extremely slow.

The function calls are counted differently depending on the language and I don't count them if the language is unknown. Right now, I only implemented basic function call counting for C (.c, .h) and Python (.py). For both languages, I keep a window of 3 tokens and check if the second token is an identifier, the third token is a '(', and the first token is not something that could indicate a function definition.

## Speed

On my computer, the solution runs in about 310ms when I print the info and 120ms when I don't.